### PR TITLE
Fixes compilation on Gentoo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,9 @@ AC_PROG_CXX
 
 PKG_CHECK_MODULES([QT5WIDGETS], [Qt5Widgets])
 
-AC_CHECK_PROGS(MOC, [moc-qt5 moc])
+QT_PATH1="$( eval $PKG_CONFIG --variable=libdir Qt5Widgets )/qt5/bin"
+QT_PATH2="$( eval $PKG_CONFIG --variable=exec_prefix Qt5Widgets )/bin"
+AC_PATH_PROGS([MOC], [moc-qt5 moc], [moc], [$QT_PATH1:$QT_PATH2])
 
 
 PKG_CHECK_MODULES([VSScript], [vapoursynth-script])


### PR DESCRIPTION
When compiling on gentoo, autotools finds qt4's moc instead of qt5 one.

The changes tell autotools the correct path where to search.