### PR TITLE
Fixes #5: std::to_string is locale sensitive on floats

### DIFF
--- a/src/wibbly/WibblyJob.cpp
+++ b/src/wibbly/WibblyJob.cpp
@@ -270,8 +270,12 @@ void WibblyJob::fieldMatchToScript(std::string &script) const {
 
     for (auto it = vfm.int_params.cbegin(); it != vfm.int_params.cend(); it++)
         script += ", " + it->first + "=" + std::to_string(it->second);
-    for (auto it = vfm.double_params.cbegin(); it != vfm.double_params.cend(); it++)
-        script += ", " + it->first + "=" + std::to_string(it->second);
+    for (auto it = vfm.double_params.cbegin(); it != vfm.double_params.cend(); it++) {
+        std::stringstream ss;
+        ss.imbue(std::locale::classic());
+        ss << it->second;
+        script += ", " + it->first + "=" + ss.str();
+	}
     for (auto it = vfm.bool_params.cbegin(); it != vfm.bool_params.cend(); it++)
         script += ", " + it->first + "=" + std::to_string((int)it->second);
 
@@ -323,8 +327,12 @@ void WibblyJob::decimationToScript(std::string &script) const {
 
     for (auto it = vdecimate.int_params.cbegin(); it != vdecimate.int_params.cend(); it++)
         script += ", " + it->first + "=" + std::to_string(it->second);
-    for (auto it = vdecimate.double_params.cbegin(); it != vdecimate.double_params.cend(); it++)
-        script += ", " + it->first + "=" + std::to_string(it->second);
+    for (auto it = vdecimate.double_params.cbegin(); it != vdecimate.double_params.cend(); it++) {
+        std::stringstream ss;
+        ss.imbue(std::locale::classic());
+        ss << it->second;
+        script += ", " + it->first + "=" + ss.str();
+	}
     for (auto it = vdecimate.bool_params.cbegin(); it != vdecimate.bool_params.cend(); it++)
         script += ", " + it->first + "=" + std::to_string((int)it->second);
 

--- a/src/wibbly/WibblyJob.cpp
+++ b/src/wibbly/WibblyJob.cpp
@@ -18,6 +18,7 @@ SOFTWARE.
 */
 
 
+#include <sstream>
 #include "RandomStuff.h"
 #include "WibblyJob.h"
 
@@ -275,7 +276,7 @@ void WibblyJob::fieldMatchToScript(std::string &script) const {
         ss.imbue(std::locale::classic());
         ss << it->second;
         script += ", " + it->first + "=" + ss.str();
-	}
+    }
     for (auto it = vfm.bool_params.cbegin(); it != vfm.bool_params.cend(); it++)
         script += ", " + it->first + "=" + std::to_string((int)it->second);
 
@@ -332,7 +333,7 @@ void WibblyJob::decimationToScript(std::string &script) const {
         ss.imbue(std::locale::classic());
         ss << it->second;
         script += ", " + it->first + "=" + ss.str();
-	}
+    }
     for (auto it = vdecimate.bool_params.cbegin(); it != vdecimate.bool_params.cend(); it++)
         script += ", " + it->first + "=" + std::to_string((int)it->second);
 


### PR DESCRIPTION
Due to regional locale, std::to_string generates different decimal separator depending on user regional settings. This is the cause of issue #5 

Setting locale globally on main() via `std::setlocale` or `std::locale::global()` did not work directly, maybe Qt is affecting this somehow?

Suggested fix is to use `std::stringstream` (which lets you specify locale) for the specific two instances where `std::to_string(float)` is required

This causes errors like this:
```
Failed to evaluate final script for job number 1. Error message:
Python exception: positional argument follows keyword argument (01.mp4, line 20)


Traceback (most recent call last):
  File "src/cython/vapoursynth.pyx", line 2239, in vapoursynth.vpy_evaluateScript
  File "/01.mp4", line 20
SyntaxError: positional argument follows keyword argument
```

See script generated for such errors to appear, specifically line 20 has `... order=1, scthresh=12,000000, chroma=1 ...`:
```python
import vapoursynth as vs

c = vs.get_core()

if wibbly_last_input_file == r'/01.mp4':
    try:
        src = vs.get_output(index=1)
        if isinstance(src, tuple):
            src = src[0]
    except KeyError:
        src = c.lsmas.LibavSMASHSource(r'/01.mp4')
        src.set_output(index=1)
else:
    src = c.lsmas.LibavSMASHSource(r'/01.mp4')
    src.set_output(index=1)
    wibbly_last_input_file = r'/01.mp4'

src = c.std.CropRel(clip=src, left=0, top=0, right=0, bottom=0)

src = c.vivtc.VFM(clip=src, micmatch=0, y1=16, blocky=16, y0=16, blockx=16, mi=80, cthresh=9, order=1, scthresh=12,000000, chroma=1, mchroma=1, field=0, mode=0, micout=1)

def copyProp(n, f):
    fout = f[0].copy()
    fout.props.WibblyFieldDifference = abs(f[0].props.WibblyEvenAverage - f[1].props.WibblyOddAverage)
    return fout

separated = c.std.SeparateFields(clip=src, tff=True)
even = c.std.SelectEvery(clip=separated, cycle=2, offsets=0)
even = c.std.PlaneStats(clipa=even, plane=0, prop='WibblyEven')
odd = c.std.SelectEvery(clip=separated, cycle=2, offsets=1)
odd = c.std.PlaneStats(clipa=odd, plane=0, prop='WibblyOdd')
even = c.std.ModifyFrame(clip=even, clips=[even, odd], selector=copyProp)
src = c.std.Interleave(clips=[even, odd])
src = c.std.DoubleWeave(clip=src, tff=True)
src = c.std.SelectEvery(clip=src, cycle=2, offsets=0)

src = c.vivtc.VDecimate(clip=src, blocky=32, blockx=32, scthresh=15,000000, dupthresh=1,100000, chroma=1, cycle=5, dryrun=True)

src = c.scxvid.Scxvid(clip=src, use_slices=True)

src.set_output()
```