### PR TITLE
Fix autotools build on master

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,8 +106,8 @@ shared_sources = $(rapidjson_sources) \
 				 src/shared/WobblyProject.cpp \
 				 src/shared/WobblyProject.h \
 				 src/shared/WobblyException.h \
-				 src/shared/WobblyShared.cpp
-				 src/shared/WobblyShared.h
+				 src/shared/WobblyShared.cpp \
+				 src/shared/WobblyShared.h \
 				 src/shared/WobblyTypes.h
 
 


### PR DESCRIPTION
Compiling under linux broke after https://github.com/dubhater/Wobbly/commit/6e70d6b0e27ea21c0a736f1db0c89a4089a1430b because \ were forgotten.